### PR TITLE
fix the main field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "type": "git",
     "url": "https://github.com/koh110/japanese-date"
   },
-  "main": "index.js",
+  "main": "src/index.js",
   "scripts": {
     "test": "NODE_PATH=. ava -v",
     "test:util": "NODE_PATH=. ava -v test/util",


### PR DESCRIPTION
Error occurred while requiring this package.

```
> const jpdate = require('japanese-date');
Error: Cannot find module 'japanese-date'
    at Function.Module._resolveFilename (module.js:455:15)
    at Function.Module._load (module.js:403:25)
    at Module.require (module.js:483:17)
    at require (internal/module.js:20:19)
    at repl:1:16
    at sigintHandlersWrap (vm.js:22:35)
    at sigintHandlersWrap (vm.js:96:12)
    at ContextifyScript.Script.runInThisContext (vm.js:21:12)
    at REPLServer.defaultEval (repl.js:313:29)
    at bound (domain.js:280:14)
```